### PR TITLE
Commit refreshed dependency hashes after updates

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -91,8 +91,8 @@ jobs:
           version="$VERSION"
 
           push_tag=false
+          git add VERSION.json ai package-lock.json bun.lock coding-agent/bun.nix
           if [[ "$VERSION_CHANGED" == "true" ]]; then
-            git add VERSION.json ai package-lock.json bun.lock coding-agent/bun.nix
             git commit -m "Update pi to ${version}"
 
             if ! git ls-remote --tags --refs origin "refs/tags/${version}" | grep -q .; then
@@ -100,12 +100,17 @@ jobs:
               push_tag=true
             fi
           else
-            git add ai package-lock.json bun.lock coding-agent/bun.nix
             if [[ "$MODELS_CHANGED" == "true" ]]; then
               git commit -m "Update models"
             else
               git commit -m "Update lockfiles"
             fi
+          fi
+
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Updater left uncommitted changes"
+            git status --short
+            exit 1
           fi
 
           git push origin "HEAD:${BRANCH}"


### PR DESCRIPTION
## Problem

The updater regenerates `npmDepsHash` and validates the package against the dirty `VERSION.json`. When only models or lockfiles change, however, the commit path does not stage `VERSION.json`. The validated hash can therefore be discarded while a new `package-lock.json` is committed, which caused the PostCSS 8.5.23 → 8.5.24 mismatch reported in #17.

## Fix

- Stage `VERSION.json` together with every other generated updater output, independently of the selected commit message.
- Fail the workflow if an update commit leaves uncommitted changes behind.

The vendored lockfile remains installed in `postPatch`. The pinned nixpkgs runs the package's `postPatch` before `npmConfigHook`, and `buildNpmPackage` also forwards `postPatch` to `fetchNpmDeps`, so the dependency FOD and package build use the same lockfile.

`master` advanced to Pi v0.83.0 while this PR was open and now contains a new, consistent lockfile/hash pair. The obsolete v0.82.1 hash-repair hunk was therefore dropped while rebasing; this PR retains the workflow fix that prevents recurrence.

Closes #17.

## Verification

- Replayed the models-only update that caused #17 and confirmed `VERSION.json` is committed with the lockfile, the tree is clean, and the result builds.
- Confirmed the v0.83.0 `npmDepsHash` matches `prefetch-npm-deps package-lock.json`.
- Built `path:.#coding-agent`.
- Ran `actionlint .github/workflows/cron.yml`.
- Ran `git diff --check`.
- Confirmed a clean merge against current `master` with `git merge-tree --write-tree`.
